### PR TITLE
Feat: responsive

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -34,7 +34,7 @@
             </a-menu>
         </a-layout-sider>
         <a-layout :style="styles.layout">
-            <a-layout-content :style="styles.layoutContent" >
+            <a-layout-content :style="styles.layoutContent">
                 <Nuxt />
             </a-layout-content>
         </a-layout>
@@ -61,19 +61,27 @@ export default Vue.extend({
     data: () => ({
         styles: {
             ...defaultStyles,
-        }
+        },
     }),
     methods: {
         onBreakpoint(isBroken: boolean) {
             if (isBroken) {
-                this.styles.layoutContent = Object.assign({}, this.styles.layoutContent, {
-                    margin: '1em .5em',
-                    padding: '1em'
-                })
+                this.styles.layoutContent = Object.assign(
+                    {},
+                    this.styles.layoutContent,
+                    {
+                        margin: '1em .5em',
+                        padding: '1em',
+                    }
+                )
             } else {
-                this.styles.layoutContent = Object.assign({}, this.styles.layoutContent, defaultStyles.layoutContent)
+                this.styles.layoutContent = Object.assign(
+                    {},
+                    this.styles.layoutContent,
+                    defaultStyles.layoutContent
+                )
             }
-        }
+        },
     },
 })
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,18 +1,11 @@
 <template>
     <main>
-        <h1>Yakuman</h1>
-        <p>
-            <NuxtLink to="/members">Members</NuxtLink>
-        </p>
-        <p>
-            <NuxtLink to="/mahjong/matches">Mahjong matches</NuxtLink>
-        </p>
-        <p>
-            <NuxtLink to="/mahjong/games">Mahjong games</NuxtLink>
-        </p>
-        <p>
-            <NuxtLink to="/mahjong/jansous">Mahjong jansous</NuxtLink>
-        </p>
+        <a-page-header
+            title="Yakuman"
+            :breadcrumb="{
+                props: { routes: [{ path: '/', breadcrumbName: 'Home' }] },
+            }"
+        />
     </main>
 </template>
 

--- a/pages/mahjong/games.vue
+++ b/pages/mahjong/games.vue
@@ -1,9 +1,6 @@
 <template>
     <main>
-        <a-page-header
-            title="戦績一覧"
-            :breadcrumb="{ props: { routes } }"
-        />
+        <a-page-header title="戦績一覧" :breadcrumb="{ props: { routes } }" />
         <a-spin size="large" tip="loading..." :spinning="loading">
             <a-table
                 :data-source="tableFormattedGames"

--- a/pages/mahjong/jansous.vue
+++ b/pages/mahjong/jansous.vue
@@ -1,9 +1,6 @@
 <template>
     <main>
-        <a-page-header
-            title="雀荘一覧"
-            :breadcrumb="{ props: { routes } }"
-        />
+        <a-page-header title="雀荘一覧" :breadcrumb="{ props: { routes } }" />
         <a-spin size="large" tip="loading..." :spinning="loading">
             <a-table :data-source="jansous" :columns="columns"></a-table>
         </a-spin>

--- a/pages/mahjong/matches.vue
+++ b/pages/mahjong/matches.vue
@@ -1,9 +1,6 @@
 <template>
     <main>
-        <a-page-header
-            title="戦一覧"
-            :breadcrumb="{ props: { routes } }"
-        />
+        <a-page-header title="戦一覧" :breadcrumb="{ props: { routes } }" />
         <a-spin size="large" tip="loading..." :spinning="loading">
             <a-table
                 :data-source="matchesWithJansou"

--- a/pages/members.vue
+++ b/pages/members.vue
@@ -1,9 +1,6 @@
 <template>
     <main>
-        <a-page-header
-            title="雀士一覧"
-            :breadcrumb="{ props: { routes } }"
-        />
+        <a-page-header title="雀士一覧" :breadcrumb="{ props: { routes } }" />
         <a-spin size="large" tip="loading..." :spinning="loading">
             <a-table :data-source="members" :columns="columns"></a-table>
         </a-spin>


### PR DESCRIPTION
closes #6 

- [x] Sider を特定幅以下で隠す/出すができるようになった。
- [x] Sider に `overflow: 'auto'` をはじめとしたスクロール関連のスタイルが必要なくなった。
- [x] 各ページのタイトル情報を `a-page-header` を使ってわかりやすくした。